### PR TITLE
updated to make it work with latest stdeb (0.7.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ The following dependencies need to be installed before being able to run the `ro
        * This must be from pip. The 0.6.0 version from debian will not work.
    * Python 3:
      * `git clone https://github.com/dirk-thomas/stdeb`
+       * On a newly installed Trusty machine I needed the `distutils-based-on-python-version-based-on-0.7.1` of the stdeb fork
      * `sudo python3.3 setup.py install`
+       * On a newly installed Trusty machine I needed the `current` branch of this repo
  * Create a debhelper file for Python 3 distutils releases:
    * `cd /usr/share/perl5/Debian/Debhelper/Buildsystem && sudo cp python_distutils.pm python3_distutils.pm`
    * Modify the new file `/usr/share/perl5/Debian/Debhelper/Buildsystem/python3_distutils.pm` with the following changes (as described in http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=597105#35 ): 

--- a/scripts/ros_release_python
+++ b/scripts/ros_release_python
@@ -73,8 +73,6 @@ def release_to_debian(name, version, upload, ignore_upload_error, python_version
     try:
         _print_subsection('Building sdist_dsc and bdist_deb package...')
         cmd = ['python%d' % python_version, 'setup.py', '--command-packages=stdeb.command', 'sdist_dsc']
-        if python_version == 2:
-            cmd.append('--workaround-548392=False')
         cmd.append('bdist_deb')
         print('# ' + ' '.join(cmd))
         subprocess.check_call(cmd)
@@ -91,7 +89,7 @@ def release_to_debian(name, version, upload, ignore_upload_error, python_version
     config = RawConfigParser()
     config.read(dput_path)
     cmds = []
-    name = name.replace('_', '' if python_version == 2 else '-')
+    name = name.replace('_', '-')
     for apt_repo in config.sections():
         changes_file = 'deb_dist/%s_%s-1_amd64.changes' % (name, version)
         assert os.path.exists(changes_file), "Failed to generate changes file '%s'" % changes_file


### PR DESCRIPTION
On a newly installed Trusty machine neither Debian packages for Python 2 nor 3 worked for me. I tried the latest stdeb version from PIP with Python 2 as well as the old forked version 0.6.0 with Python3. This pull request captures the changes I had to make to this repo which uses the current version of stdeb (0.7.1) from either PIP (for Python 2) or from the new branch on my fork (for Python 3).
