### PR TITLE
update script and doc to use stdeb 0.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The following dependencies need to be installed before being able to run the `ro
  * Install the latest / a customized version of stdeb:
    * Python 2:
      * `sudo pip install stdeb`
-       * This must be from pip. The 0.6.0 version from debian will not work.
+       * This must be at least version 0.7.1 from pip. The version 0.6.0 from Debian will not work.
    * Python 3:
      * `git clone https://github.com/dirk-thomas/stdeb`
      * `sudo python3.3 setup.py install`

--- a/scripts/ros_release_python
+++ b/scripts/ros_release_python
@@ -72,26 +72,22 @@ def release_to_debian(name, version, upload, ignore_upload_error, python_version
 
     try:
         _print_subsection('Building sdist_dsc and bdist_deb package...')
-        cmd = ['python%d' % python_version, 'setup.py', '--command-packages=stdeb.command', 'sdist_dsc']
-        if python_version == 2:
-            cmd.append('--workaround-548392=False')
-        cmd.append('bdist_deb')
+        cmd = ['python%d' % python_version, 'setup.py', '--command-packages=stdeb.command', 'sdist_dsc', 'bdist_deb']
         print('# ' + ' '.join(cmd))
         subprocess.check_call(cmd)
     finally:
         if os.path.islink('stdeb.cfg'):
             os.unlink('stdeb.cfg')
-        if python_version != 2:
-            tarball = '%s-%s.tar.gz' % (name, version)
-            if os.path.isfile(tarball):
-                os.unlink(tarball)
+        tarball = '%s-%s.tar.gz' % (name, version)
+        if os.path.isfile(tarball):
+            os.unlink(tarball)
 
     dput_path = _get_config_path('dput.cf')
 
     config = RawConfigParser()
     config.read(dput_path)
     cmds = []
-    name = name.replace('_', '' if python_version == 2 else '-')
+    name = name.replace('_', '-')
     for apt_repo in config.sections():
         changes_file = 'deb_dist/%s_%s-1_amd64.changes' % (name, version)
         assert os.path.exists(changes_file), "Failed to generate changes file '%s'" % changes_file
@@ -120,22 +116,21 @@ def includedeb(name, version, upload, python_version):
     config.read(stdeb_file)
     suites = config.get('DEFAULT', 'Suite').split(' ')
 
-    folder_name = name.replace('_', '' if python_version == 2 else '-')
-    pkg_name = 'python%s-%s' % ('' if python_version == 2 else str(python_version), name.replace('_', '-'))
+    name = name.replace('_', '-')
+    pkg_name = 'python%s-%s' % ('' if python_version == 2 else str(python_version), name)
 
     includedeb_path = _get_config_path('includedeb.cf')
 
     config = RawConfigParser()
     config.read(includedeb_path)
     cmds = []
-    name = name.replace('_', '' if python_version == 2 else '-')
     for apt_repo in config.sections():
         basepath = config.get(apt_repo, 'basepath')
         includedeb_command = config.get(apt_repo, 'includedeb_command')
         for suite in suites:
             cmd = includedeb_command.split(' ')
             cmd.append(suite)
-            cmd.append('%s/pool/main/%s/%s/%s_%s-1_all.deb' % (basepath, name[0], folder_name, pkg_name, version))
+            cmd.append('%s/pool/main/%s/%s/%s_%s-1_all.deb' % (basepath, name[0], name, pkg_name, version))
             cmds.append(cmd)
 
     _print_subsection('Propagate Debian package to listed suites...')


### PR DESCRIPTION
I think this is the way to get it working with the current packages available. It also removes some of the code blocks which differ between Python 2 and 3.

For `catkin_pkg` it generates the "right" Python 2 version dependency for me:

```
Build-Depends: python-all (>= 2.6.6-3), debhelper (>= 7.4.3)
X-Python-Version: >= 2.6
```

@tfoote @wjwwood Please review - eventually trying it in a virtualenv (to not break your working system using stdeb 0.6) might be a good idea.
