### PR TITLE
Switch to upload only to ros_bootstrap repo

### DIFF
--- a/resources/dput.cf
+++ b/resources/dput.cf
@@ -1,23 +1,7 @@
-[all-building]
+[all-bootstrap]
 method                  = scp
 login                   = rosbuild
 fqdn                    = repos.ros.org
-incoming                = /var/www/repos/building/queue/all
+incoming                = /var/www/repos/ros_bootstrap/queue/all
 run_dinstall            = 0
-post_upload_command     = ssh rosbuild@repos.ros.org -- /usr/bin/reprepro -b /var/www/repos/building --ignore=emptyfilenamepart -V processincoming all
-
-[all-ros-shadow-fixed]
-method                  = scp
-login                   = rosbuild
-fqdn                    = repos.ros.org
-incoming                = /var/www/repos/ros-shadow-fixed/ubuntu/queue/all
-run_dinstall            = 0
-post_upload_command     = ssh rosbuild@repos.ros.org -- /usr/bin/reprepro -b /var/www/repos/ros-shadow-fixed/ubuntu --ignore=emptyfilenamepart -V processincoming all
-
-[all-ros]
-method                  = scp
-login                   = rosbuild
-fqdn                    = repos.ros.org
-incoming                = /var/www/repos/ros/ubuntu/queue/all
-run_dinstall            = 0
-post_upload_command     = ssh rosbuild@repos.ros.org -- /usr/bin/reprepro -b /var/www/repos/ros/ubuntu --ignore=emptyfilenamepart -V processincoming all
+post_upload_command     = ssh rosbuild@repos.ros.org -- /usr/bin/reprepro -b /var/www/repos/ros_bootstrap --ignore=emptyfilenamepart -V processincoming all


### PR DESCRIPTION
This will then propagate via import_upstream to all repos. Re: https://github.com/ros-infrastructure/reprepro-updater/pull/17 and https://github.com/ros-infrastructure/buildfarm_deployment_config/pull/4