### PR TITLE
use pkg_name given that the name variable has been renamed in 766a9f8…

### DIFF
--- a/scripts/ros_release_python
+++ b/scripts/ros_release_python
@@ -286,7 +286,7 @@ def main(argv=sys.argv[1:]):
                             args.ignore_upload_error, python_version,
                             setup_env_vars=setup_env_vars)
                 else:
-                    include(name, version, args.debian_version, args.upload, python_version)
+                    include(pkg_name, version, args.debian_version, args.upload, python_version)
 
             if not args.include and 'pip' in args.targets:
                 release_to_pip(pkg_name, version, args.upload)


### PR DESCRIPTION
…7ca92b54eaef7af651f2fca304fc4d902

Follow-up of https://github.com/ros-infrastructure/ros_release_python/pull/15
This is needed for the codepath using --include