### PR TITLE
remove register and use Python 3 for upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ The following dependencies need to be installed before being able to run the `ro
    * `sudo apt-get install python-all python3-all`
  * Install PIP:
    * `sudo apt-get install python-pip python3-pip`
+ * Install up-to-date setuptools via PIP (if necessary):
+   * `pip3 install --upgrade setuptools`
+   * See https://packaging.python.org/guides/tool-recommendations/#publishing-platform-migration for more information why that is necessary.
  * Install stdeb (0.8.4 or higher) via PIP:
    * `sudo pip install [--upgrade] stdeb`
    * `sudo pip3 install [--upgrade] stdeb`

--- a/scripts/ros_release_python
+++ b/scripts/ros_release_python
@@ -17,7 +17,7 @@ import sys
 
 def get_name_and_version():
     _print_section('Determine package name and version')
-    output = subprocess.check_output(['python', 'setup.py', '--name', '--version'])
+    output = subprocess.check_output(['python3', 'setup.py', '--name', '--version'])
     lines = output.splitlines()
     assert len(lines) == 2
     name = lines[0].decode('ascii')
@@ -30,12 +30,12 @@ def get_name_and_version():
 def release_to_pip(name, version, upload):
     _print_section('Release Python package to PIP')
 
-    cmd = ['python2', 'setup.py', 'sdist']
-    upload_targets = ['register', 'upload']
+    cmd = ['python3', 'setup.py', 'sdist']
+    upload_targets = ['upload']
     msgs = ['Building sdist package']
     if upload:
         cmd.extend(upload_targets)
-        msgs.append('register and upload package to PIP')
+        msgs.append('upload package to PIP')
     _print_subsection('%s...' % ', '.join(msgs))
     if upload:
         print('# ' + ' '.join(cmd))


### PR DESCRIPTION
`register` has been deprecated for a while.

With the shutdown of the old PyPI API the default Ubuntu Xenial package won't allow you to upload anymore. See https://packaging.python.org/guides/tool-recommendations/#publishing-platform-migration

Since we are more likely to use up-to-date versions of e.g. `setuptools` with Python 3 I changed it to use python3 for uploading.

This was necessary for me to release a new version of  a Python package. I do have a current version of `setuptools` installed for the user using `pip3` though.