### PR TITLE
strip .buildinfo entries from changes files

### DIFF
--- a/scripts/ros_release_python
+++ b/scripts/ros_release_python
@@ -127,6 +127,9 @@ def strip_buildinfo(path):
     with open(path, 'w') as h:
         for line in lines:
             if line.startswith(' ') and line.endswith('.buildinfo'):
+                print(
+                    'Removing .buildinfo from changes file [%s] for older reprepro compatibility. '
+                    'https://github.com/ros-infrastructure/ros_release_python/pull/22' % path)
                 continue
             h.write(line + '\n')
 

--- a/scripts/ros_release_python
+++ b/scripts/ros_release_python
@@ -96,12 +96,14 @@ def release_to_debian(name, version, debian_version, upload, ignore_upload_error
     for apt_repo in config.sections():
         changes_file = 'deb_dist/%s_%s-%s_source.changes' % (source_pkg_name, version, debian_version)
         assert os.path.exists(changes_file), "Failed to generate source changes file '%s'" % changes_file
+        strip_buildinfo(changes_file)
         cmds.append(['dput', '-u', '-c', dput_path, apt_repo, changes_file])
 
     # upload binary (.deb) packages
     for apt_repo in config.sections():
         changes_file = 'deb_dist/%s_%s-%s_amd64.changes' % (source_pkg_name, version, debian_version)
         assert os.path.exists(changes_file), "Failed to generate binary changes file '%s'" % changes_file
+        strip_buildinfo(changes_file)
         cmds.append(['dput', '-u', '-c', dput_path, apt_repo, changes_file])
 
     if upload:
@@ -116,6 +118,17 @@ def release_to_debian(name, version, debian_version, upload, ignore_upload_error
             except subprocess.CalledProcessError:
                 if not ignore_upload_error:
                     raise
+
+
+def strip_buildinfo(path):
+    with open(path, 'r') as h:
+        content = h.read()
+    lines = content.splitlines()
+    with open(path, 'w') as h:
+        for line in lines:
+            if line.startswith(' ') and line.endswith('.buildinfo'):
+                continue
+            h.write(line + '\n')
 
 
 def clean_all(names):


### PR DESCRIPTION
When building Debian packages with a newer `dpkg` version (e.g. on Bionic) the changes files contain `.buildinfo` entries which the old version of `reprepro` used on repos.ros.org can't handle.

This patch strips these lines from the changes files which allows to import the packages successfully.