### PR TITLE
Document to install fakeroot and debhelper

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ The following dependencies need to be installed before being able to run the `ro
 
  * Install dput:
    * `sudo apt-get install dput`
+ * Install fakeroot:
+   * `sudo apt-get install fakeroot`
+ * Install debhelper:
+   * `sudo apt-get install debhelper`
  * Install apt-file:
    * `sudo apt-get install apt-file`
    * and run:


### PR DESCRIPTION
On bionic (edit: and xenial) without these packages I get the following tracebacks when calling `scripts/ros_release_python`

```
dpkg-buildpackage: error: fakeroot not found, either install the fakeroot
package, specify a command with the -r option, or run this as root
Traceback (most recent call last):
  File "setup.py", line 29, in <module>
    license='BSD'
  File "/home/developer/.local/lib/python2.7/site-packages/setuptools/__init__.py", line 129, in setup
    return distutils.core.setup(**attrs)
  File "/usr/lib/python2.7/distutils/core.py", line 151, in setup
    dist.run_commands()
  File "/usr/lib/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/home/developer/.local/lib/python2.7/site-packages/stdeb/command/sdist_dsc.py", line 140, in run
    remove_expanded_source_dir=self.remove_expanded_source_dir,
  File "/home/developer/.local/lib/python2.7/site-packages/stdeb/util.py", line 1421, in build_dsc
    dpkg_genchanges(cwd=fullpath_repackaged_dirname)
  File "/home/developer/.local/lib/python2.7/site-packages/stdeb/util.py", line 538, in dpkg_genchanges
    process_command(args,cwd=cwd)
  File "/home/developer/.local/lib/python2.7/site-packages/stdeb/util.py", line 183, in process_command
    check_call(args, cwd=cwd)
  File "/home/developer/.local/lib/python2.7/site-packages/stdeb/util.py", line 46, in check_call
    raise CalledProcessError(retcode)
stdeb.util.CalledProcessError: 255
```
```
dpkg-checkbuilddeps: error: Unmet build dependencies: debhelper (>= 7.4.3)
dpkg-buildpackage: warning: build dependencies/conflicts unsatisfied; aborting
dpkg-buildpackage: warning: (Use -d flag to override.)
Traceback (most recent call last):
  File "setup.py", line 29, in <module>
    license='BSD'
  File "/home/developer/.local/lib/python2.7/site-packages/setuptools/__init__.py", line 129, in setup
    return distutils.core.setup(**attrs)
  File "/usr/lib/python2.7/distutils/core.py", line 151, in setup
    dist.run_commands()
  File "/usr/lib/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/home/developer/.local/lib/python2.7/site-packages/stdeb/command/sdist_dsc.py", line 140, in run
    remove_expanded_source_dir=self.remove_expanded_source_dir,
  File "/home/developer/.local/lib/python2.7/site-packages/stdeb/util.py", line 1421, in build_dsc
    dpkg_genchanges(cwd=fullpath_repackaged_dirname)
  File "/home/developer/.local/lib/python2.7/site-packages/stdeb/util.py", line 538, in dpkg_genchanges
    process_command(args,cwd=cwd)
  File "/home/developer/.local/lib/python2.7/site-packages/stdeb/util.py", line 183, in process_command
    check_call(args, cwd=cwd)
  File "/home/developer/.local/lib/python2.7/site-packages/stdeb/util.py", line 46, in check_call
    raise CalledProcessError(retcode)
stdeb.util.CalledProcessError: 3
```