### PR TITLE
clear artifacts before building / uploading to pypi

### DIFF
--- a/scripts/ros_release_python
+++ b/scripts/ros_release_python
@@ -318,6 +318,7 @@ def main(argv=sys.argv[1:]):
                         include(name, version, debian_version, args.upload, python_version)
 
             if not args.include and 'pip' in args.targets:
+                clean_all(names)
                 release_to_pip(pkg_name, version, args.upload)
 
             break  # while True


### PR DESCRIPTION
Otherwise when releasing packages like `catkin_pkg` which are being split into two Debian packages (one with the suffix `-modules`) those artifacts are still around in the `dist` directory. The later twine invocation will then upload those unintentionally.