### PR TITLE
Add include support for aptly backed bootstrap repository.

### DIFF
--- a/resources/include.cf
+++ b/resources/include.cf
@@ -1,4 +1,5 @@
 [ros-bootstrap]
-basepath           = /var/www/repos/ros_bootstrap
-includedsc_command = ssh rosbuild@repos.ros.org -- /usr/bin/reprepro -b /var/www/repos/ros_bootstrap -V includedsc
-includedeb_command = ssh rosbuild@repos.ros.org -- /usr/bin/reprepro -b /var/www/repos/ros_bootstrap -V includedeb
+basepath           = /home/apt/public/repos/ros_bootstrap
+includedsc_command = ssh apt@aptly.osrfoundation.org -- /usr/bin/aptly repo add ros_bootstrap-{suite} {basepath}/pool/main/{pkg_initial}/{pkg_name}/{pkg_name}_{version}-{debian_version}.dsc
+includedeb_command = ssh apt@aptly.osrfoundation.org -- /usr/bin/aptly repo add ros_bootstrap-{suite} {basepath}/pool/main/{pkg_initial}/{pkg_name}/{pkg_name}_{version}-{debian_version}_all.deb
+post_include_command = ssh apt@aptly.osrfoundation.org -- /home/apt/bin/snapshot-and-publish-all ros_bootstrap

--- a/scripts/ros_release_python
+++ b/scripts/ros_release_python
@@ -186,14 +186,22 @@ def include(name, version, debian_version, upload, python_version):
         includedsc_command = config.get(apt_repo, 'includedsc_command')
         includedeb_command = config.get(apt_repo, 'includedeb_command')
         for suite in suites:
-            cmd = includedsc_command.split(' ')
-            cmd.append(suite)
-            cmd.append('%s/pool/main/%s/%s/%s_%s-%s.dsc' % (basepath, pkg_name[0], pkg_name, pkg_name, version, debian_version))
-            cmds.append(cmd)
-            cmd = includedeb_command.split(' ')
-            cmd.append(suite)
-            cmd.append('%s/pool/main/%s/%s/%s_%s-%s_all.deb' % (basepath, pkg_name[0], pkg_name, pkg_name, version, debian_version))
-            cmds.append(cmd)
+            cmds.append(includedsc_command.format(
+                suite=suite,
+                basepath=basepath,
+                pkg_initial=pkg_name[0],
+                pkg_name=pkg_name,
+                version=version,
+                debian_version=debian_version).split(' '))
+            cmds.append(includedeb_command.format(
+                suite=suite,
+                basepath=basepath,
+                pkg_initial=pkg_name[0],
+                pkg_name=pkg_name,
+                version=version,
+                debian_version=debian_version).split(' '))
+        if config.has_option(apt_repo, 'post_include_command'):
+            cmds.append(config.get(apt_repo, 'post_include_command').split(' '))
 
     _print_subsection('Propagate Debian package to listed suites...')
     for cmd in cmds:


### PR DESCRIPTION
This updates the `--include` flag to work with the current aptly-based bootstrap repository. Fixes #31.

Unlike #26 I actually had to touch the script itself.
Mostly I took information assumptions the script made about the structure of the include commands and moved it into the config values themselves.

I also needed to add a post_include_command option to trigger the snapshot and publish operation needed to push the include out to the published repositories.
