### PR TITLE
Add a Dockerfile and instructions for how to invoke ros_release_python without requiring a local workspace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:bionic
+
+ENV DEBIAN_FRONTEND=non-interactive
+RUN apt-get update && apt-get install -qy \
+    dput \
+    fakeroot \
+    debhelper \
+    apt-file \
+    python-setuptools \
+    python3-setuptools \
+    python-all \
+    python3-all \
+    python-pip \
+    python3-pip \
+    openssh-client # scp for dput
+
+RUN pip install -U stdeb
+RUN pip3 install -U stdeb
+RUN pip3 install -U pip
+RUN pip3 install -U setuptools
+RUN pip3 install -U twine
+
+RUN mkdir -p /ros_release_python/scripts
+RUN mkdir -p /ros_release_python/resources
+ADD scripts/ros_release_python /ros_release_python/scripts
+ADD resources/dput.cf /ros_release_python/resources
+ADD resources/include.cf /ros_release_python/resources
+
+# Needed for dput
+ENV USER=$USER

--- a/README.md
+++ b/README.md
@@ -82,3 +82,14 @@ Sync into building / testing / main repos
 
 This tool only uploads the generated Debian packages into the `bootstrap` repository.
 To make the packages available in the building / testing / main repos the Jenkins job to "import upstream" must be run.
+
+
+Quick usage via rocker
+----------------------
+
+If you have your ssh and pypi credentials available in your home directory.
+
+* `docker build -t rrp .`
+* `rocker --home --user rrp`
+* `cd <PATH TO PACKAGE>`
+* `/ros_release_python/scripts/ros_release_python <ARGS>`


### PR DESCRIPTION
I've been using this approach for a while now and didn't realize that I hadn't shared it back. 