### PR TITLE
Move forward to focal and remove python2 from main instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,17 @@
-FROM ubuntu:bionic
+FROM ubuntu:focal
 
 ENV DEBIAN_FRONTEND=non-interactive
 RUN apt-get update && apt-get install -qy \
     dput \
     fakeroot \
     debhelper \
+    dh-python \
     apt-file \
-    python-setuptools \
     python3-setuptools \
-    python-all \
     python3-all \
-    python-pip \
     python3-pip \
     openssh-client # scp for dput
 
-RUN pip install -U stdeb
 RUN pip3 install -U stdeb
 RUN pip3 install -U pip
 RUN pip3 install -U setuptools
@@ -28,3 +25,7 @@ ADD resources/include.cf /ros_release_python/resources
 
 # Needed for dput
 ENV USER=$USER
+
+# Workaround for https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1003252
+# As suggested https://stackoverflow.com/a/76474591/604099
+ENV SETUPTOOLS_USE_DISTUTILS=stdlib

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,11 @@ RUN apt-get update && apt-get install -qy \
     python3-setuptools \
     python3-all \
     python3-pip \
-    openssh-client # scp for dput
+    openssh-client \
+    sudo 
+
+# scp for dput 
+# sudo Avoid reinstall with rocker
 
 RUN pip3 install -U stdeb
 RUN pip3 install -U pip

--- a/README.md
+++ b/README.md
@@ -12,42 +12,29 @@ The following dependencies need to be installed before being able to run the `ro
    * `sudo apt-get install fakeroot`
  * Install debhelper:
    * `sudo apt-get install debhelper`
+ * Install dh-python:
+   * `sudo apt-get install dh-python`
  * Install apt-file:
    * `sudo apt-get install apt-file`
    * and run:
    * `sudo apt-file update`
  * Install setuptools:
-   * `sudo apt-get install python-setuptools python3-setuptools`
-   * The Python 2 package can be skipped if only Python 3 releases are made.
+   * `sudo apt-get install python3-setuptools`
  * Install Python "all":
-   * `sudo apt-get install python-all python3-all`
-   * The Python 2 package can be skipped if only Python 3 releases are made.
+   * `sudo apt-get install python3-all`
  * Install PIP:
-   * `sudo apt-get install python-pip python3-pip`
-   * The Python 2 package can be skipped if only Python 3 releases are made.
-     As of Ubuntu Focal there is no `python-pip` package anymore - it needs to be installed via [get-pip](https://pip.pypa.io/en/stable/installing/#installing-with-get-pip-py) instead.
+   * `sudo apt-get install python3-pip`
+
  * Install up-to-date setuptools via PIP (if necessary):
    * `pip3 install --upgrade setuptools`
    * See https://packaging.python.org/guides/tool-recommendations/#publishing-platform-migration for more information why that is necessary.
  * Install `stdeb` (0.9.1 or higher) via PIP:
-   * `sudo pip install [--upgrade] stdeb`
    * `sudo pip3 install [--upgrade] stdeb`
    * Do **not** use the Debian packages on Wily and newer.
      They will embed a newer Python dependency into the control file (2.7.5, 3.3.2) which breaks the package on older distributions like *Precise*.
  * Install `twine` via PIP:
    * `sudo pip3 install [--upgrade] twine`
 
-Note: Make sure `pip` is for Python2, because sometimes when you install pip for Python3 (like on precise) it overwrites `pip` as pip for Python3. You can explicitly invoke pip from Python2 like this:
-
-```
-$ sudo python -c "from pkg_resources import load_entry_point; load_entry_point('pip', 'console_scripts', 'pip')()" install -U stdeb
-```
-
-Or with Python3 like this:
-
-```
-$ sudo python3 -c "from pkg_resources import load_entry_point; load_entry_point('pip', 'console_scripts', 'pip')()" install -U stdeb
-```
 
 Prepare a Python package
 ------------------------
@@ -77,6 +64,8 @@ Releasing Python 2 packages targeting Ubuntu pre-Focal from Focal
 As of stdeb 0.9.1 a `Python2-Depends-Name` option is allowed in stdeb.cfg to override the Python 2 package name.
 You can use this feature to force the Python 2 package name to be `python` rather than `python2` as it is on Ubuntu Focal.
 
+You will also need to install the python 2 equivalents of the above packages on your system.
+
 Sync into building / testing / main repos
 -----------------------------------------
 
@@ -93,3 +82,6 @@ If you have your ssh and pypi credentials available in your home directory.
 * `rocker --home --user rrp`
 * `cd <PATH TO PACKAGE>`
 * `/ros_release_python/scripts/ros_release_python <ARGS>`
+
+
+On one of my machines I had to increase ulimit to help fakeroot https://github.com/moby/moby/issues/27195 as of rocker 0.2.18 you can add `--ulimit nofile=1024` to work around that. 

--- a/resources/dput.cf
+++ b/resources/dput.cf
@@ -2,6 +2,6 @@
 method                  = scp
 login                   = apt
 fqdn                    = aptly.osrfoundation.org
-incoming                = /home/apt/ros_bootstrap/incoming
+incoming                = /var/repos/ros_bootstrap/incoming
 run_dinstall            = 0
-post_upload_command     = ssh apt@aptly.osrfoundation.org -- /home/apt/bin/publish-incoming-packages ros_bootstrap
+post_upload_command     = ssh apt@aptly.osrfoundation.org -- /var/repos/bin/publish-incoming-packages ros_bootstrap

--- a/resources/include.cf
+++ b/resources/include.cf
@@ -1,5 +1,5 @@
 [ros-bootstrap]
-basepath           = /home/apt/public/repos/ros_bootstrap
+basepath           = /var/repos/public/repos/ros_bootstrap
 includedsc_command = ssh apt@aptly.osrfoundation.org -- /usr/bin/aptly repo add ros_bootstrap-{suite} {basepath}/pool/main/{pkg_initial}/{pkg_name}/{pkg_name}_{version}-{debian_version}.dsc
 includedeb_command = ssh apt@aptly.osrfoundation.org -- /usr/bin/aptly repo add ros_bootstrap-{suite} {basepath}/pool/main/{pkg_initial}/{pkg_name}/{pkg_name}_{version}-{debian_version}_all.deb
-post_include_command = ssh apt@aptly.osrfoundation.org -- /home/apt/bin/snapshot-and-publish-all ros_bootstrap
+post_include_command = ssh apt@aptly.osrfoundation.org -- /var/repos/bin/snapshot-and-publish-all ros_bootstrap


### PR DESCRIPTION
Tested with a rocker release just now