### PR TITLE
Add instructions for running the release container without rocker.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,8 @@ ADD scripts/ros_release_python /ros_release_python/scripts
 ADD resources/dput.cf /ros_release_python/resources
 ADD resources/include.cf /ros_release_python/resources
 
+# For running without rocker homedir mapping.
+RUN mkdir /projects
+
 # Needed for dput
 ENV USER=$USER

--- a/README.md
+++ b/README.md
@@ -93,3 +93,13 @@ If you have your ssh and pypi credentials available in your home directory.
 * `rocker --home --user rrp`
 * `cd <PATH TO PACKAGE>`
 * `/ros_release_python/scripts/ros_release_python <ARGS>`
+
+Quick usage via docker / podman
+-------------------------------
+
+If you have your ssh and pypi credentials available in your home directory.
+
+* `docker build -t rrp .`
+* `./docker-run.sh <PATH TO PACKAGE>`
+* `cd /projects/<PACKAGE>`
+* `/ros_release_python/scripts/ros_release_python <ARGS>`

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+PROJECT_DIR="$1"
+PROJECT_NAME="$(basename "$PROJECT_DIR")"
+
+if [ -z "$SSH_AUTH_SOCK" ]; then
+	echo "No ssh-agent socket available. You probably won't be able to push to the ROS bootstrap repository."
+fi
+
+docker run -ti -eSSH_AUTH_SOCK="$SSH_AUTH_SOCK" \
+	-v"${SSH_AUTH_SOCK}:${SSH_AUTH_SOCK}" \
+	-v"${PROJECT_DIR}:/projects/${PROJECT_NAME}" \
+	-v"${HOME}/.pypirc:/root/.pypirc" \
+	rrp


### PR DESCRIPTION
For people who don't use Rocker, here's a basic script based on how I've
been using my homegrown container setup for performing these releases.

This works locally but I've not yet asked anyone else to try with it.
I expect the rocker workflow to be the more common one but I wanted to stick this here for reference.
