### PR TITLE
Install an updated version of wheel to allow pypi uploads.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -qy \
 RUN pip install -U stdeb
 RUN pip3 install -U stdeb
 RUN pip3 install -U pip
+RUN pip3 install -U wheel  # Older versions use an unsupported metadata format.
 RUN pip3 install -U setuptools
 RUN pip3 install -U twine
 


### PR DESCRIPTION
Apparently metadata format version 2.0 is a radically different and no
longer supported metadata version from a superseded PEP compared to 1.2
or 2.1+ which is a much more incremental change.

Updating the wheel version allows pypi uploads which were previously
blocked by the server rejecting Metadata 2.0 wheel uploads.
